### PR TITLE
一行内容里有多个信息时，sess不会识别

### DIFF
--- a/static/js.js
+++ b/static/js.js
@@ -289,7 +289,7 @@ function sendRequest() {
         apiUrl = apiUrlSelect.value;
     }
 
-    let apiKeys = apiKeyInput.value.split(/[,\s，\n]+/);
+    let apiKeys = parseKeys(apiKeyInput.value);
 
     if (apiKeys.length === 0) {
         alert("未匹配到 API-KEY，请检查输入内容");
@@ -297,6 +297,22 @@ function sendRequest() {
     }
 
     alert("成功匹配到 API Key，确认后开始查询：" + apiKeys);
+
+    function parseKeys(input) {
+        let lines = input.split(/\n/);
+        let result = [];
+        for (let line of lines) {
+            if (line.includes("sk-") && line.includes("sess-")) {
+                let sessKey = line.match(/sess-[^\-]+/)[0];
+                result.push(sessKey);
+            }
+            else if (line.includes("sk-")) {
+                let skKey = line.match(/sk-[^\-]+/)[0];
+                result.push(skKey);
+            }
+        }
+        return result;
+    }
 
     let lastQueryPromise = null;
 


### PR DESCRIPTION
Fixes #22

添加了识别类似

tenbtxxxxxxxo@mail.com----w3xxxxxWnD----sk-cmE5AxxxxxxxkFJ5fPxxxxxMGOxzmFjR----sess-4pgpxxxxxbf3NN6M4SiJNKPk
这种查询信息，当一行里有sess时，取sess的值，当没有sess时，取sk的值。在碰到----或者结束时截止